### PR TITLE
Add support for favicon

### DIFF
--- a/mcserver/objects/packet_handler.py
+++ b/mcserver/objects/packet_handler.py
@@ -18,6 +18,7 @@ from mcserver.classes.player import Player
 from mcserver.objects.player_registry import PlayerRegistry
 from mcserver.objects.server_core import ServerCore
 from mcserver.utils.logger import debug, error
+from mcserver.utils.misc import read_favicon
 
 if TYPE_CHECKING:
     from mcserver.classes.client_message import ClientMessage
@@ -120,8 +121,11 @@ class PacketHandler:
                 "protocol": msg.protocol_version
             }
         }
-        # TODO: Server icon
+        favicon = read_favicon()
+        if favicon:
+            d["favicon"] = f"data:image/png;base64,{favicon}"
 
+        
         msg.send_packet(
             "status_response",
             msg.buffer_type.pack_json(d)
@@ -187,7 +191,7 @@ class PacketHandler:
             async with session.get(url, timeout=ServerCore.auth_timeout) as resp:
                 data = await resp.json()
                 msg.conn.uuid = UUID(data["id"])
-
+                
         cls.update_protocol(msg, "play")
         return PlayerRegistry.add_player(msg.conn)
 

--- a/mcserver/objects/packet_handler.py
+++ b/mcserver/objects/packet_handler.py
@@ -18,6 +18,7 @@ from mcserver.classes.player import Player
 from mcserver.objects.player_registry import PlayerRegistry
 from mcserver.objects.server_core import ServerCore
 from mcserver.utils.logger import debug, error
+from mcserver.utils.misc import read_favicon
 
 if TYPE_CHECKING:
     from mcserver.classes.client_message import ClientMessage
@@ -118,10 +119,13 @@ class PacketHandler:
                     msg.protocol_version,
                     "???"),
                 "protocol": msg.protocol_version
-            }
+            },
         }
-        # TODO: Server icon
+        favicon = read_favicon()
+        if favicon:
+            d["favicon"] = f"data:image/png;base64,{favicon}"
 
+        
         msg.send_packet(
             "status_response",
             msg.buffer_type.pack_json(d)
@@ -187,7 +191,7 @@ class PacketHandler:
             async with session.get(url, timeout=ServerCore.auth_timeout) as resp:
                 data = await resp.json()
                 msg.conn.uuid = UUID(data["id"])
-
+                
         cls.update_protocol(msg, "play")
         return PlayerRegistry.add_player(msg.conn)
 

--- a/mcserver/objects/server_core.py
+++ b/mcserver/objects/server_core.py
@@ -1,3 +1,4 @@
+# Stdlib
 from typing import List
 
 # External Libraries

--- a/mcserver/utils/misc.py
+++ b/mcserver/utils/misc.py
@@ -1,8 +1,9 @@
 # Stdlib
+from base64 import b64encode
 from copy import deepcopy
 import inspect
-from os.path import join, dirname
-from typing import Union
+from os.path import join, isfile, dirname
+from typing import Union, Optional
 
 # External Libraries
 from quarry.types.buffer import Buffer1_7, Buffer1_9, Buffer1_13
@@ -44,7 +45,7 @@ DEFAULT_SERVER_PROPERTIES = {
     'prevent-proxy-connections': False,
     'use-native-transport': True,
     'enable-rcon': False,
-    'motd': 'A Minecraft Server'
+    'motd': 'A Minecraft Server',
 }
 
 AnyBuffer = Union[Buffer1_7, Buffer1_9, Buffer1_13]
@@ -65,7 +66,15 @@ def open_local(filename: str):
     dir_name = dirname(inspect.stack()[1].filename)
     return open(join(dir_name, filename))
 
-
+def read_favicon() -> Optional[str]:
+    if not isfile('server.icon'):
+        return None
+        
+    with open('server.icon', "rb") as f:
+        content = b64encode(f.read())
+    
+    return content.decode()
+    
 def read_config(file):
     data = {}
     for line in file.readlines():

--- a/mcserver/utils/misc.py
+++ b/mcserver/utils/misc.py
@@ -1,7 +1,8 @@
 # Stdlib
+from base64 import b64encode
 from copy import deepcopy
 import inspect
-from os.path import join, dirname
+from os.path import join, isfile, dirname
 from typing import Union
 
 # External Libraries
@@ -44,7 +45,7 @@ DEFAULT_SERVER_PROPERTIES = {
     'prevent-proxy-connections': False,
     'use-native-transport': True,
     'enable-rcon': False,
-    'motd': 'A Minecraft Server'
+    'motd': 'A Minecraft Server',
 }
 
 AnyBuffer = Union[Buffer1_7, Buffer1_9, Buffer1_13]
@@ -65,7 +66,15 @@ def open_local(filename: str):
     dir_name = dirname(inspect.stack()[1].filename)
     return open(join(dir_name, filename))
 
-
+def read_favicon() -> str:
+    if not isfile('server.icon'):
+        return False
+        
+    with open('server.icon', "rb") as f:
+        content = b64encode(f.read())
+    
+    return content.decode()
+    
 def read_config(file):
     data = {}
     for line in file.readlines():


### PR DESCRIPTION
Set favicon through `favicon` property as a file path relative to execution point. Send `favicon` on server ping action if defined as a base64 data. 